### PR TITLE
Create loadbalancer health monitors by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Set the default reclaim policy to delete.
+- Set default to create Loadbalancer health monitors 
 
 ## [0.1.1] - 2022-01-04
 

--- a/helm/cloud-provider-openstack-app/values.yaml
+++ b/helm/cloud-provider-openstack-app/values.yaml
@@ -27,6 +27,7 @@ cloudConfig:
   loadBalancer:
     internal-lb: false
     floating-network-id:
+    create-monitor: true
     # network-id:
     # subnet-id:
   # blockStorage:


### PR DESCRIPTION
Create health monitors by default. This is set using the below setting.

> create-monitor Indicates whether or not to create a health monitor for the service load balancer. A health monitor required for services that declare externalTrafficPolicy: Local. Default: false

https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md

Related to: https://github.com/giantswarm/giantswarm/issues/20495