### PR TITLE
Add default VolumeSnapshotClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add default VolumeSnapshotClass for Cinder CSI.
+
 ## [0.4.0] - 2022-04-01
 
 ### Changed

--- a/helm/cloud-provider-openstack-app/charts/openstack-cinder-csi/values.yaml
+++ b/helm/cloud-provider-openstack-app/charts/openstack-cinder-csi/values.yaml
@@ -121,7 +121,14 @@ storageClass:
     isDefault: false
     allowVolumeExpansion: true
 # any kind of custom StorageClasses
-#   custom: |-
+  custom: |-
+    ---
+    apiVersion: snapshot.storage.k8s.io/v1beta1
+    kind: VolumeSnapshotClass
+    metadata:
+      name: csi-cinder-snapclass
+    driver: cinder.csi.openstack.org
+    deletionPolicy: Delete
 #     ---
 #     apiVersion: storage.k8s.io/v1
 #     kind: StorageClass
@@ -132,13 +139,6 @@ storageClass:
 #     allowVolumeExpansion: true
 #     parameters:
 #       type: SAS
-#     ---
-#     apiVersion: snapshot.storage.k8s.io/v1beta1
-#     kind: VolumeSnapshotClass
-#     metadata:
-#       name: csi-cinder-snapclass
-#     driver: cinder.csi.openstack.org
-#     deletionPolicy: Delete
 
 # You may set ID of the cluster where openstack-cinder-csi is deployed. This value will be appended
 # to volume metadata in newly provisioned volumes as `cinder.csi.openstack.org/cluster=<cluster ID>`.


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/752

This PR adds default VolumeSnapshotClass for Cinder CSI

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
