### PR TITLE
Bump VolumeSnapshotClass version to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - OCCM now only run on control-plane nodes
+- Bump `VolumeSnapshotClass` version to v1 since v1beta1 is deprecated.
+- Add default annotation to VolumeSnapshotClass.
 
 ## [0.5.1] - 2022-04-29
 

--- a/helm/cloud-provider-openstack-app/values.yaml
+++ b/helm/cloud-provider-openstack-app/values.yaml
@@ -63,10 +63,12 @@ openstack-cinder-csi:
       allowVolumeExpansion: true
     custom: |-
       ---
-      apiVersion: snapshot.storage.k8s.io/v1beta1
+      apiVersion: snapshot.storage.k8s.io/v1
       kind: VolumeSnapshotClass
       metadata:
         name: csi-cinder-snapclass
+        annotations:
+          snapshot.storage.kubernetes.io/is-default-class: "true"
       driver: cinder.csi.openstack.org
       deletionPolicy: Delete
 openstack-cloud-controller-manager:


### PR DESCRIPTION
This PR:

- bumps VolumeSnapshotClass versiton to v1 since v1beta1 is deprecated.
- adds default annotation to VolumeSnapshotClass since I found that it is necessary while testing.

### Testing

- [x] fresh install works
- [x] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
