### PR TITLE
Remove ca-certs mount from openstack-cloud-controller-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove semi-broken default `ca-certs` mount from
+  `openstack-cloud-controller-manager`. This fixes running it on Flatcar. See
+  https://github.com/kubernetes/cloud-provider-openstack/issues/1923
+
 ## [0.6.0] - 2022-05-23
 
 ### Changed
@@ -36,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2022-03-28
 
-### Added 
+### Added
 
 - Enable snapshotter by default.
 
@@ -53,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Set the default reclaim policy to delete.
-- Set default to create Loadbalancer health monitors 
+- Set default to create Loadbalancer health monitors
 
 ## [0.1.1] - 2022-01-04
 

--- a/helm/cloud-provider-openstack-app/charts/openstack-cloud-controller-manager/values.yaml
+++ b/helm/cloud-provider-openstack-app/charts/openstack-cloud-controller-manager/values.yaml
@@ -84,9 +84,6 @@ extraVolumes:
   - name: flexvolume-dir
     hostPath:
       path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-  - name: ca-certs
-    hostPath:
-      path: /etc/ssl/certs
   - name: k8s-certs
     hostPath:
       path: /etc/kubernetes/pki
@@ -94,9 +91,6 @@ extraVolumes:
 extraVolumeMounts:
   - name: flexvolume-dir
     mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-    readOnly: true
-  - name: ca-certs
-    mountPath: /etc/ssl/certs
     readOnly: true
   - name: k8s-certs
     mountPath: /etc/kubernetes/pki


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/778