### PR TITLE
Add quotes to values in cloud.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add quotes to values in `cloud-config` secret to fix broken conf files when a value starts with `#` character.
+
 ## [0.6.1] - 2022-06-22
 
 ### Fixed

--- a/helm/cloud-provider-openstack-app/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
+++ b/helm/cloud-provider-openstack-app/charts/openstack-cloud-controller-manager/templates/_helpers.tpl
@@ -51,26 +51,26 @@ Create cloud-config makro.
 {{- define "cloudConfig" -}}
 [Global]
 {{- range $key, $value := .Values.cloudConfig.global }}
-{{ $key }} = {{ $value }}
+{{ $key }} = {{ $value | quote }}
 {{- end }}
 
 [Networking]
 {{- range $key, $value := .Values.cloudConfig.networking }}
-{{ $key }} = {{ $value }}
+{{ $key }} = {{ $value | quote }}
 {{- end }}
 
 [LoadBalancer]
 {{- range $key, $value := .Values.cloudConfig.loadBalancer }}
-{{ $key }} = {{ $value }}
+{{ $key }} = {{ $value | quote }}
 {{- end }}
 
 [BlockStorage]
 {{- range $key, $value := .Values.cloudConfig.blockStorage }}
-{{ $key }} = {{ $value }}
+{{ $key }} = {{ $value | quote }}
 {{- end }}
 
 [Metadata]
 {{- range $key, $value := .Values.cloudConfig.metadata }}
-{{ $key }} = {{ $value }}
+{{ $key }} = {{ $value | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
When a value in cloud.conf file starts with '#' char,
it breaks file format and recognized as comment. We need to
add quotes around strings.

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how cloud-provider-openstack-app can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cloud-provider-openstack-app installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
