### PR TITLE
Fix tolerations for k8s 1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `openstack-cloud-controller-manager` tolerations for k8s 1.24.
+
 ## [0.6.1] - 2022-06-22
 
 ### Fixed

--- a/helm/cloud-provider-openstack-app/values.yaml
+++ b/helm/cloud-provider-openstack-app/values.yaml
@@ -87,8 +87,7 @@ openstack-cloud-controller-manager:
     - key: node.cloudprovider.kubernetes.io/uninitialized
       value: "true"
       effect: NoSchedule
-    - key: node-role.kubernetes.io/controlplane
-      value: "true"
+    - key: node-role.kubernetes.io/control-plane
       effect: NoSchedule
     - key: node-role.kubernetes.io/master
       effect: NoSchedule


### PR DESCRIPTION
The label in k8s 1.24 is as follow

`node-role.kubernetes.io/control-plane: ""
`

Therefore, we need to use `control-plane` instead of `controlplane` and we should set the value as empty in tolerations.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
